### PR TITLE
Resolve for base url trailing slash + minor layout cleanup

### DIFF
--- a/src/Pipl.php
+++ b/src/Pipl.php
@@ -13,10 +13,6 @@ use GuzzleHttp\ClientInterface;
  */
 class Pipl
 {
-
-    /**
-     * @var ClientInterface
-     */
     protected $client;
 
     public function __construct(ClientInterface $client = null)
@@ -24,31 +20,27 @@ class Pipl
         $this->client = $client ?? (new Client());
     }
 
-    /**
-     * @param array $arrayOfFields
-     * @return mixed
-     * @throws Exception
-     */
-    public function search(array $arrayOfFields)
+    public function search(array $fields)
     {
-        if (empty($arrayOfFields)) {
-            $error = "Search function parameter can't be empty";
-            throw new Exception($error);
+        if (empty($fields)) {
+            throw new Exception("Search function parameter can't be empty");
         }
         
-        $url = $this->buildUrl($arrayOfFields);
+        $url = $this->buildUrl($fields);
         $response = $this->client->get($url);
         return json_decode($response->getBody(), true);
     }
 
-    protected function buildUrl(array $arrayOfFields)
+    protected function buildUrl(array $fields)
     {
         $key = env('PIPL_API_KEY');
-        $url = env('PIPL_API_BASE_URL', 'http://api.pipl.com/search/') . "?key={$key}";
-        foreach ($arrayOfFields as $key => $value) {
-            $url .= "&$key=$value";
+        $baseUrl = rtrim(env('PIPL_API_BASE_URL', 'http://api.pipl.com/search/'), '/') . '/';
+        $url = $baseUrl . "?key={$key}";
 
+        foreach ($fields as $key => $value) {
+            $url .= "&$key=$value";
         }
+
         return $url;
     }
 }

--- a/src/Pipl.php
+++ b/src/Pipl.php
@@ -34,8 +34,8 @@ class Pipl
     protected function buildUrl(array $fields)
     {
         $key = env('PIPL_API_KEY');
-        $baseUrl = rtrim(env('PIPL_API_BASE_URL', 'http://api.pipl.com/search/'), '/') . '/';
-        $url = $baseUrl . "?key={$key}";
+        $baseUrl = rtrim(env('PIPL_API_BASE_URL', 'http://api.pipl.com/search/'), '/');
+        $url = $baseUrl . "/?key={$key}";
 
         foreach ($fields as $key => $value) {
             $url .= "&$key=$value";


### PR DESCRIPTION
Here is one more. 

I have added the code part to ignore whether the base url has a trailing slash or not. This one strips it out if it has one, and adds it manually so that env can accept `www.blah.com` as well as `www.blah.com/` as its env variable. 

I have also renamed the variable `$arrayOfFields` to `$fields` only, since you have already type-hinted it is an array. Looks cleaner to me now.

Regards